### PR TITLE
Convert README.md to README.txt for releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,5 @@ configure_file(textures/font1_2_test.data textures/font3_0_test.data COPYONLY)
 configure_file(textures/font4_0_test.data textures/font4_0_test.data COPYONLY)
 
 # README.md
-configure_file(README.md README.md COPYONLY)
+configure_file(README.md README.txt NEWLINE_STYLE CRLF)
 


### PR DESCRIPTION
Closes #26 

I still think this is a bad solution, and users / editor authors (particularly Microsoft) should know better, to support `.md` as a valid extension, and Unix line endings.

I consider this an ugly workaround.